### PR TITLE
修复了在新版青龙上不能正确获取路径的问题

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -67,12 +67,12 @@ class config_get(object):
     def get_config_path():
         ql_old = "/ql/config/"
         ql_new = "/ql/data/config/"
-        if os.path.isdir(ql_old):
-            print('成功 当前环境为青龙面板v2.12- 继续执行\n')
-            return ql_old
-        elif os.path.isdir(ql_new):
+        if os.path.isdir(ql_new):
             print('成功 当前环境为青龙面板v2.12+ 继续执行\n')
             return ql_new
+        elif os.path.isdir(ql_old):
+            print('成功 当前环境为青龙面板v2.12- 继续执行\n')
+            return ql_old
         else:
             print('失败 请检查环境')
             exit(0)


### PR DESCRIPTION
原逻辑是如果'/ql/config'目录存在就认为当前是老青龙，
然而在我这(青龙v2.13.6) '/ql/config'和'/ql/data/config'都存在，以至于最后无法生成配置文件。

为此我调换了判断的先后顺序，首选检测新路径。
fixs #19 